### PR TITLE
Changed stats:setPanic(...) to stats:set(CharacterStat.PANIC...) for Homichlophobia panic increment check to remove errors

### DIFF
--- a/Contents/mods/Evolving Traits World/42.15/media/lua/client/ETWTraitsLogic.lua
+++ b/Contents/mods/Evolving Traits World/42.15/media/lua/client/ETWTraitsLogic.lua
@@ -125,7 +125,7 @@ local function fogTraits(player, fogIntensity)
 			local panicIncrease = 4 * fogIntensity * SBvars.HomichlophobiaMultiplier
 			local resultingPanic = stats:get(CharacterStat.PANIC) + panicIncrease
 			if resultingPanic <= 50 then
-				stats:setPanic(math.max(0, resultingPanic))
+				stats:set(CharacterStat.PANIC, math.max(0, resultingPanic))
 				logETW("ETW Logger | fogTraits(): panicIncrease:" .. panicIncrease)
 			end
 			local stressIncrease = 0.04 * fogIntensity * SBvars.HomichlophobiaMultiplier


### PR DESCRIPTION
This line was throwing errors when I was playing. Fixing this has removed that error and correctly increased player Panic when afraid of the fog and out in the fog